### PR TITLE
Add cmake to Dockerfile

### DIFF
--- a/geo-ci.Dockerfile
+++ b/geo-ci.Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
     libsqlite3-dev \
     libtiff5-dev \
     make \
+    cmake \
     pkg-config \
     sqlite3 \
     wget


### PR DESCRIPTION
Seems to be required by the build script for `proj-sys`: https://github.com/urschrei/rust-proj/runs/1182749054#step:5:144