### PR TITLE
proj-ci containers (and extract out shared libproj-builder container)

### DIFF
--- a/geo-ci.Dockerfile
+++ b/geo-ci.Dockerfile
@@ -1,41 +1,10 @@
 # https://hub.docker.com/orgs/georust/geo-ci
 
 # ------------------------------------------------------------------------------
-# PROJ build stage
-# ------------------------------------------------------------------------------
-
-FROM ubuntu:20.04 as proj_builder
-
-# Specify where PROJ will get installed
-ARG DESTDIR="/build"
-
-# Install dependencies
-RUN apt-get update \
-  && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
-    clang \
-    libcurl4-gnutls-dev \
-    libsqlite3-dev \
-    libtiff5-dev \
-    make \
-    build-essential \
-    cmake \
-    pkg-config \
-    sqlite3 \
-    wget
-
-# Compile and install
-RUN wget https://github.com/OSGeo/PROJ/releases/download/7.1.0/proj-7.1.0.tar.gz \
-  && tar -xzvf proj-7.1.0.tar.gz \
-  && cd proj-7.1.0 \
-  && ./configure --prefix=/usr \
-  && make -j$(nproc) \
-  && make install
-
-# ------------------------------------------------------------------------------
 # tarpaulin build stage
 # ------------------------------------------------------------------------------
 
-FROM rust:latest as tarpaulin_builder
+FROM rust:latest as tarpaulin-builder
 
 RUN cargo install cargo-tarpaulin --root /build
 
@@ -46,6 +15,7 @@ RUN cargo install cargo-tarpaulin --root /build
 FROM ubuntu:20.04
 
 # clang and libtiff5 are needed to build geo with `--features use-proj`
+# note: I think we can remove clang if we make bindgen optional, see https://github.com/georust/proj-sys/issues/24
 # curl is needed to run tarpaulin
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
@@ -55,14 +25,10 @@ RUN apt-get update \
     curl \
     git \
     libtiff5 \
+    pkg-config \
     rustc \
   && rm -rf /var/lib/apt/lists/*
 
-# Copy PROJ artifacts from proj_builder
-COPY --from=proj_builder /build/usr/share/proj/ /usr/share/proj/
-COPY --from=proj_builder /build/usr/include/ /usr/include/
-COPY --from=proj_builder /build/usr/bin/ /usr/bin/
-COPY --from=proj_builder /build/usr/lib/ /usr/lib/
+COPY --from=libproj-builder /build/usr /usr
+COPY --from=tarpaulin-builder /build/bin /usr/bin
 
-# Copy tarpauling artifacts from proj_builder
-COPY --from=tarpaulin_builder /build/bin/ /usr/bin

--- a/libproj-builder.Dockerfile
+++ b/libproj-builder.Dockerfile
@@ -1,0 +1,42 @@
+# https://hub.docker.com/orgs/georust/libproj-builder
+
+# Builds libproj from source
+
+FROM ubuntu:20.04
+
+# Install dependencies
+RUN apt-get update \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    clang \
+    libcurl4-gnutls-dev \
+    libsqlite3-dev \
+    libtiff5-dev \
+    cmake \
+    pkg-config \
+    sqlite3 \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+# Compile and install to /build
+#
+# Note libproj is not installed to a system directory, so that a staged build
+# can install from this container using something like:
+#
+#    # PROJ stage
+#    FROM libproj-builder as libproj-builder
+#    ...
+#    # Maybe some additional stages
+#    ...
+#    # Output Container
+#    FROM my-base-image
+#    ...
+#    COPY --from=libproj-builder /build/usr /usr
+#    ...
+RUN wget https://github.com/OSGeo/PROJ/releases/download/7.1.0/proj-7.1.0.tar.gz
+RUN tar -xzvf proj-7.1.0.tar.gz
+RUN mv proj-7.1.0 proj-src
+WORKDIR /proj-src
+RUN ./configure --prefix=/usr
+RUN make -j$(nproc)
+RUN make DESTDIR=/build install
+RUN rm -fr /proj-src

--- a/proj-ci-without-system-proj.Dockerfile
+++ b/proj-ci-without-system-proj.Dockerfile
@@ -1,0 +1,14 @@
+# https://hub.docker.com/orgs/georust/proj-ci-without-system-proj
+
+# This container is based on the libproj-builder container, which has built
+# libproj, and thus has all the dependencies for building proj from source, but
+# we intentionaly have not installed it to a system path.
+FROM libproj-builder
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+    cargo \
+    clang \
+    rustc \
+  && rm -rf /var/lib/apt/lists/*
+

--- a/proj-ci-without-system-proj.Dockerfile
+++ b/proj-ci-without-system-proj.Dockerfile
@@ -2,7 +2,7 @@
 
 # This container is based on the libproj-builder container, which has built
 # libproj, and thus has all the dependencies for building proj from source, but
-# we intentionaly have not installed it to a system path.
+# we intentionally have not installed it to a system path.
 FROM libproj-builder
 
 RUN apt-get update \
@@ -11,4 +11,3 @@ RUN apt-get update \
     clang \
     rustc \
   && rm -rf /var/lib/apt/lists/*
-

--- a/proj-ci.Dockerfile
+++ b/proj-ci.Dockerfile
@@ -1,0 +1,12 @@
+# https://hub.docker.com/orgs/georust/proj-ci
+
+FROM libproj-builder
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+    cargo \
+    clang \
+    rustc \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=libproj-builder /build/usr /usr


### PR DESCRIPTION
Because we are using multi-stage builds (as of ccd97a576a00538ad767260c0cad689ee9931cef), deps installed in the first
stage are not usable in the resultant container.

Generally, we want a system libproj to be preinstalled, however for the
purposes of testing the bundled_proj we now have a separate container
that comes without system libproj reinstalled.