### PR TITLE
use rust base image (upgrades rust from 1.43 -> 1.49)

### DIFF
--- a/geo-ci.Dockerfile
+++ b/geo-ci.Dockerfile
@@ -4,15 +4,14 @@
 # tarpaulin build stage
 # ------------------------------------------------------------------------------
 
-FROM rust:latest as tarpaulin-builder
-
+FROM rust:1.49 as tarpaulin-builder
 RUN cargo install cargo-tarpaulin --root /build
 
 # ------------------------------------------------------------------------------
 # Final stage
 # ------------------------------------------------------------------------------
 
-FROM ubuntu:20.04
+FROM rust:1.49
 
 # clang and libtiff5 are needed to build geo with `--features use-proj`
 # note: I think we can remove clang if we make bindgen optional, see https://github.com/georust/proj-sys/issues/24
@@ -26,7 +25,6 @@ RUN apt-get update \
     git \
     libtiff5 \
     pkg-config \
-    rustc \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=georust/libproj-builder /build/usr /usr

--- a/geo-ci.Dockerfile
+++ b/geo-ci.Dockerfile
@@ -19,7 +19,6 @@ FROM rust:1.49
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
     ca-certificates \
-    cargo \
     clang \
     curl \
     git \

--- a/geo-ci.Dockerfile
+++ b/geo-ci.Dockerfile
@@ -26,6 +26,6 @@ RUN apt-get update \
     pkg-config \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=georust/libproj-builder /build/usr /usr
+COPY --from=georust/libproj-builder:rust-1.49 /build/usr /usr
 COPY --from=tarpaulin-builder /build/bin /usr/bin
 

--- a/libproj-builder.Dockerfile
+++ b/libproj-builder.Dockerfile
@@ -2,7 +2,7 @@
 
 # Builds libproj from source
 
-FROM ubuntu:20.04
+FROM rust:1.49 as tarpaulin-builder
 
 # Install dependencies
 RUN apt-get update \

--- a/libproj-builder.Dockerfile
+++ b/libproj-builder.Dockerfile
@@ -2,7 +2,7 @@
 
 # Builds libproj from source
 
-FROM rust:1.49 as tarpaulin-builder
+FROM rust:1.49
 
 # Install dependencies
 RUN apt-get update \

--- a/proj-ci-without-system-proj.Dockerfile
+++ b/proj-ci-without-system-proj.Dockerfile
@@ -7,7 +7,5 @@ FROM georust/libproj-builder
 
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
-    cargo \
     clang \
-    rustc \
   && rm -rf /var/lib/apt/lists/*

--- a/proj-ci-without-system-proj.Dockerfile
+++ b/proj-ci-without-system-proj.Dockerfile
@@ -3,7 +3,7 @@
 # This container is based on the libproj-builder container, which has built
 # libproj, and thus has all the dependencies for building proj from source, but
 # we intentionally have not installed it to a system path.
-FROM georust/libproj-builder
+FROM georust/libproj-builder:rust-1.49
 
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \

--- a/proj-ci.Dockerfile
+++ b/proj-ci.Dockerfile
@@ -1,12 +1,10 @@
 # https://hub.docker.com/orgs/georust/proj-ci
 
-FROM georust/libproj-builder
+FROM georust/libproj-builder:rust-1.49
 
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
-    cargo \
     clang \
-    rustc \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=georust/libproj-builder /build/usr /usr

--- a/proj-ci.Dockerfile
+++ b/proj-ci.Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get update \
     clang \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=georust/libproj-builder /build/usr /usr
+COPY --from=georust/libproj-builder:rust-1.49 /build/usr /usr


### PR DESCRIPTION
I don't feel like I have a great workflow for building/publishing/testing changes to our docker images...

- I've got some tests based on this running locally which seem promising (still running).
- I'm going to publish to a temporary tag and push up a branch to proj to test it shortly.
- Once all of that passes, I'll publish to the `:latest` images, at which point our various CI's should work.

FIXES #6 