### PR TITLE
Update PROJ to 8.1.0

### DIFF
--- a/rust-1.51/libproj-builder.Dockerfile
+++ b/rust-1.51/libproj-builder.Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update \
 #    ...
 #    COPY --from=libproj-builder /build/usr /usr
 #    ...
-RUN wget https://github.com/OSGeo/PROJ/releases/download/7.2.1/proj-7.2.1.tar.gz
-RUN tar -xzvf proj-7.2.1.tar.gz
-RUN mv proj-7.2.1 proj-src
+RUN wget https://github.com/OSGeo/PROJ/releases/download/8.1.0/proj-8.1.0.tar.gz
+RUN tar -xzvf proj-8.1.0.tar.gz
+RUN mv proj-8.1.0 proj-src
 WORKDIR /proj-src
 RUN ./configure --prefix=/usr
 RUN make -j$(nproc)

--- a/rust-1.52/libproj-builder.Dockerfile
+++ b/rust-1.52/libproj-builder.Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update \
 #    ...
 #    COPY --from=libproj-builder /build/usr /usr
 #    ...
-RUN wget https://github.com/OSGeo/PROJ/releases/download/7.2.1/proj-7.2.1.tar.gz
-RUN tar -xzvf proj-7.2.1.tar.gz
-RUN mv proj-7.2.1 proj-src
+RUN wget https://github.com/OSGeo/PROJ/releases/download/8.1.0/proj-8.1.0.tar.gz
+RUN tar -xzvf proj-8.1.0.tar.gz
+RUN mv proj-8.1.0 proj-src
 WORKDIR /proj-src
 RUN ./configure --prefix=/usr
 RUN make -j$(nproc)

--- a/rust-1.53/libproj-builder.Dockerfile
+++ b/rust-1.53/libproj-builder.Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update \
 #    ...
 #    COPY --from=libproj-builder /build/usr /usr
 #    ...
-RUN wget https://github.com/OSGeo/PROJ/releases/download/7.2.1/proj-7.2.1.tar.gz
-RUN tar -xzvf proj-7.2.1.tar.gz
-RUN mv proj-7.2.1 proj-src
+RUN wget https://github.com/OSGeo/PROJ/releases/download/8.1.0/proj-8.1.0.tar.gz
+RUN tar -xzvf proj-8.1.0.tar.gz
+RUN mv proj-8.1.0 proj-src
 WORKDIR /proj-src
 RUN ./configure --prefix=/usr
 RUN make -j$(nproc)


### PR DESCRIPTION
This updates our Docker images to use PROJ `8.1.0`. Once this PR merges, I'll clobber our existing `1.51`, `1.52`, and `1.53` tags with the updated images.

This PR lays the groundwork for updates to `proj-sys`, `proj`, and `geo`.