### PR TITLE
update to rust 1.79 bump msrv since older versions fail to build spade

### DIFF
--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: ["1.74", "1.79", "1.80"]
+        rust_version: ["1.74", "1.78", "1.79"]
 
     steps:
     - name: Check out repository
@@ -82,7 +82,7 @@ jobs:
           {image: proj-ci, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --no-default-features && cargo test --features bundled_proj && cargo test --features network && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=0 cargo test && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test --features bundled_proj"},
           {image: proj-ci-without-system-proj, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --features bundled_proj && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test"}
           ]
-        rust_version: ["1.74", "1.79", "1.80"]
+        rust_version: ["1.74", "1.78", "1.79"]
 
     steps:
     - name: Check out repository

--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -49,6 +49,7 @@ jobs:
       with:
         file: ./dockerfiles/${{ env.MAIN_IMAGE_NAME }}
         push: false
+        pull: true
         load: true
         platforms: linux/amd64
         tags: ghcr.io/${{ github.repository_owner }}/${{ env.MAIN_IMAGE_NAME }}:proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}

--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: ["1.74", 1.79, 1.80]
+        rust_version: ["1.74", "1.79", "1.80"]
 
     steps:
     - name: Check out repository
@@ -81,7 +81,7 @@ jobs:
           {image: proj-ci, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --no-default-features && cargo test --features bundled_proj && cargo test --features network && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=0 cargo test && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test --features bundled_proj"},
           {image: proj-ci-without-system-proj, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --features bundled_proj && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test"}
           ]
-        rust_version: ["1.74", 1.79, 1.80]
+        rust_version: ["1.74", "1.79", "1.80"]
 
     steps:
     - name: Check out repository

--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: ["1.70", 1.76, 1.77]
+        rust_version: ["1.74", 1.79, 1.80]
 
     steps:
     - name: Check out repository
@@ -81,7 +81,7 @@ jobs:
           {image: proj-ci, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --no-default-features && cargo test --features bundled_proj && cargo test --features network && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=0 cargo test && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test --features bundled_proj"},
           {image: proj-ci-without-system-proj, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --features bundled_proj && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test"}
           ]
-        rust_version: ["1.70", 1.76, 1.77]
+        rust_version: ["1.74", 1.79, 1.80]
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
Build error is:
```
cargo check --all-targets --no-default-features

https://github.com/georust/geo/actions/runs/10101238242/job/27934367105?pr=1197

error[E0446]: crate-private type `PointWithIndex<V>` in public interface
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/spade-2.10.0/src/delaunay_core/bulk_load.rs:357:1
    |
342 |   pub(crate) struct PointWithIndex<V> {
    |   ----------------------------------- `PointWithIndex<V>` declared as crate-private
...
357 | / pub fn bulk_load_stable<V, T, T2, Constructor>(
358 | |     constructor: Constructor,
359 | |     elements: Vec<V>,
360 | | ) -> Result<T, InsertionError>
...   |
370 | |     >,
371 | |     Constructor: FnOnce(Vec<PointWithIndex<V>>) -> Result<T2, InsertionError>,
    | |______________________________________________________________________________^ can't leak crate-private type
```