### PR TITLE
1.85 MSRV, libproj 9.6.2

### DIFF
--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -12,7 +12,7 @@ on:
   merge_group:
 
 env:
-  LIBPROJ_VERSION: 9.6.0
+  LIBPROJ_VERSION: 9.6.2
   MAIN_IMAGE_NAME: libproj-builder
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: ["1.83", "1.86", "1.87"]
+        rust_version: ["1.85", "1.86", "1.88"]
 
     steps:
     - name: Check out repository
@@ -84,7 +84,7 @@ jobs:
           {image: proj-ci, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --no-default-features && cargo test --features bundled_proj && cargo test --features network && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=0 cargo test && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test --features bundled_proj"},
           {image: proj-ci-without-system-proj, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --features bundled_proj && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test"}
           ]
-        rust_version: ["1.83", "1.86", "1.87"]
+        rust_version: ["1.85", "1.86", "1.88"]
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

As per discussion in https://github.com/georust/docker-images/pull/44#discussion_r2201807591, these images will provide CI images for a forthcoming bump of `geo`'s `i_overlay` dependency, necessitating an MSRV of 1.85. We are opportunistically also going to bump the `proj` crate's libproj to 9.6.2, then depend upon that new crate version in `geo`.