### PR TITLE
Add Rust 1.94 and Rust 1.95

### DIFF
--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -26,7 +26,7 @@ jobs:
         # Include the 2 latest rust versions, plus all the MSRV from the following crates:
         #  - proj: https://github.com/georust/proj/blob/main/.github/workflows/test.yml
         #  - geo / geo-types: https://github.com/georust/geo/blob/main/.github/workflows/test.yml
-        rust_version: ["1.82", "1.88", "1.92", "1.93"]
+        rust_version: ["1.82", "1.88", "1.94", "1.95"]
 
     steps:
     - name: Check out repository
@@ -95,7 +95,7 @@ jobs:
           {image: proj-ci, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --no-default-features && cargo test --features bundled_proj && cargo test --features network && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=0 cargo test && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test --features bundled_proj"},
           {image: proj-ci-without-system-proj, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --features bundled_proj && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test"}
           ]
-        rust_version: ["1.88", "1.92", "1.93"]
+        rust_version: ["1.88", "1.94", "1.95"]
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

Ordinarily we'd have separate PRs, but we forgot about 1.94 and 1.95 is stable now.
