### PR TITLE
Pass libproj-builder between CI jobs via OCI artifact

### DIFF
--- a/.github/workflows/imagebuild.yml
+++ b/.github/workflows/imagebuild.yml
@@ -26,7 +26,7 @@ jobs:
         # Include the 2 latest rust versions, plus all the MSRV from the following crates:
         #  - proj: https://github.com/georust/proj/blob/main/.github/workflows/test.yml
         #  - geo / geo-types: https://github.com/georust/geo/blob/main/.github/workflows/test.yml
-        rust_version: ["1.82", "1.85", "1.92", "1.93"]
+        rust_version: ["1.82", "1.88", "1.92", "1.93"]
 
     steps:
     - name: Check out repository
@@ -48,29 +48,36 @@ jobs:
         docker buildx use mybuilder
         docker buildx inspect --bootstrap
 
-    - name: Build and export main image to Docker
+    - name: Build and export base image as OCI tarball
       uses: docker/build-push-action@v6
       with:
         file: ./dockerfiles/${{ env.MAIN_IMAGE_NAME }}
-        push: false
         pull: true
-        load: true
         platforms: linux/amd64
         tags: ghcr.io/${{ github.repository_owner }}/${{ env.MAIN_IMAGE_NAME }}:proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}
+        outputs: type=oci,dest=/tmp/${{ env.MAIN_IMAGE_NAME }}-rust-${{ matrix.rust_version }}.tar
+        cache-to: type=gha,mode=max,scope=main-${{ matrix.rust_version }}
+        cache-from: type=gha,scope=main-${{ matrix.rust_version }}
         build-args: |
               RUST_VERSION=${{ matrix.rust_version }}
               PROJ_VERSION=${{ env.LIBPROJ_VERSION }}
 
-    - name: Push main image
+    - name: Upload base image artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.MAIN_IMAGE_NAME }}-rust-${{ matrix.rust_version }}
+        path: /tmp/${{ env.MAIN_IMAGE_NAME }}-rust-${{ matrix.rust_version }}.tar
+        retention-days: 1
+
+    - name: Push base image
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/build-push-action@v6
       with:
         file: ./dockerfiles/${{ env.MAIN_IMAGE_NAME }}
         push: true
-        load: false
         # platforms: linux/amd64,linux/arm64
         tags: ghcr.io/${{ github.repository_owner }}/${{ env.MAIN_IMAGE_NAME }}:proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}
-        outputs: type=docker,dest=/tmp/${{ env.MAIN_IMAGE_NAME }}-proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}.tar
+        cache-from: type=gha,scope=main-${{ matrix.rust_version }}
         build-args: |
               RUST_VERSION=${{ matrix.rust_version }}
               PROJ_VERSION=${{ env.LIBPROJ_VERSION }}
@@ -88,7 +95,7 @@ jobs:
           {image: proj-ci, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --no-default-features && cargo test --features bundled_proj && cargo test --features network && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=0 cargo test && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test --features bundled_proj"},
           {image: proj-ci-without-system-proj, testcmd: "git clone https://github.com/georust/proj && cd proj && cargo test --features bundled_proj && cd proj-sys && _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC=1 cargo test"}
           ]
-        rust_version: ["1.85", "1.92", "1.93"]
+        rust_version: ["1.88", "1.92", "1.93"]
 
     steps:
     - name: Check out repository
@@ -110,6 +117,17 @@ jobs:
         docker buildx use mybuilder
         docker buildx inspect --bootstrap
 
+    - name: Download base image artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.MAIN_IMAGE_NAME }}-rust-${{ matrix.rust_version }}
+        path: /tmp/main-image
+
+    - name: Extract OCI layout
+      run: |
+        mkdir -p /tmp/oci
+        tar -xf /tmp/main-image/${{ env.MAIN_IMAGE_NAME }}-rust-${{ matrix.rust_version }}.tar -C /tmp/oci
+
     - name: Build ${{ matrix.subimages.image }}
       uses: docker/build-push-action@v6
       with:
@@ -118,6 +136,8 @@ jobs:
         load: true
         platforms: linux/amd64
         tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.subimages.image }}:proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}
+        build-contexts: |
+          ghcr.io/${{ github.repository_owner }}/${{ env.MAIN_IMAGE_NAME }}:proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}=oci-layout:///tmp/oci
         build-args: |
               RUST_VERSION=${{ matrix.rust_version }}
               PROJ_VERSION=${{ env.LIBPROJ_VERSION }}
@@ -132,10 +152,10 @@ jobs:
       with:
         file: ./dockerfiles/${{ matrix.subimages.image }}
         push: true
-        load: false
         # platforms: linux/amd64,linux/arm64
         tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.subimages.image }}:proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}
-        outputs: type=docker,dest=/tmp/${{ matrix.subimages.image }}-proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}.tar
+        build-contexts: |
+          ghcr.io/${{ github.repository_owner }}/${{ env.MAIN_IMAGE_NAME }}:proj-${{ env.LIBPROJ_VERSION }}-rust-${{ matrix.rust_version }}=oci-layout:///tmp/oci
         build-args: |
               RUST_VERSION=${{ matrix.rust_version }}
               PROJ_VERSION=${{ env.LIBPROJ_VERSION }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ running CI against each patch seems like overkill at this point.
 
 **New images are built by Github Actions and published to the Github Container Registry if tests pass**
 
+## CI Workflow
+
+The pipeline in `.github/workflows/imagebuild.yml` has two stages:
+
+1. `build_main_image` builds `libproj-builder` for each Rust version in the
+   matrix and writes it to an OCI tarball, which is uploaded as a workflow
+   artifact. On pushes to `main` the same image is also published to
+   `ghcr.io/georust/libproj-builder:proj-<PROJ_VERSION>-rust-<RUST_VERSION>`.
+   The `type=gha` buildx cache is shared between the export and push steps so
+   the main-branch push is a cache hit rather than a full rebuild.
+
+2. `build_dependent_images` downloads the matching `libproj-builder` artifact,
+   extracts it to an OCI layout on the runner, then builds each dependent
+   image (`geo-ci`, `proj-ci`, `proj-ci-without-system-proj`). The dependent
+   Dockerfiles keep `FROM ghcr.io/georust/libproj-builder:...`, but buildx's
+   `build-contexts` input redirects that reference to the local OCI layout.
+   This is how PRs that introduce a new Rust version can build the dependent
+   images without the base image yet existing on `ghcr.io`. Pushes to `main`
+   then publish the tested dependent images to `ghcr.io` as well.
+
 ## How to Update the Rust Version
 
 


### PR DESCRIPTION
## Summary

PRs that introduce a new rust version can't build the dependent images because #51 gated the main-image push behind main-only, and the dependent Dockerfiles `FROM ghcr.io/.../libproj-builder:…`. On a PR the base tag doesn't yet exist, so the dependent build fails with "not found" (see #52 for a live example).

This change makes `build_main_image` export each variant as an OCI tarball artifact, and `build_dependent_images` download the matching artifact and redirect the `FROM` via buildx's `build-contexts` (`oci-layout:///tmp/oci`). No ghcr.io writes are needed on PRs. Also adds a `type=gha` buildx cache so the on-main `Push main image` step is a cache hit rather than a from-scratch rebuild.

## Validation plan

master's matrix already has all its base images in ghcr.io, so its own CI is uninformative. The real test is to rebase #52 onto this branch — #52 introduces 1.94 and 1.95 which have no ghcr.io base image, so its dependent-image jobs can only go green if the artifact/`build-contexts` path works.

## Test plan

- [ ] This PR's own CI passes (regression check against existing rust versions).
- [ ] After rebase, #52's `build_dependent_images` jobs pass for 1.94 and 1.95 without any ghcr.io push having happened.
- [ ] After merging to main, the `Push main image` step on main still pushes correctly (cache hit from `type=gha`).