### PR TITLE
Switch to rust:*-slim-bullseye as base

### DIFF
--- a/dockerfiles/geo-ci
+++ b/dockerfiles/geo-ci
@@ -8,7 +8,7 @@ ARG RUST_VERSION
 ARG PROJ_VERSION
 
 FROM ghcr.io/georust/libproj-builder:proj-${PROJ_VERSION}-rust-${RUST_VERSION} as libproj-builder
-FROM rust:$RUST_VERSION-bullseye
+FROM rust:$RUST_VERSION-slim-bullseye
 
 ARG RUST_VERSION
 ARG PROJ_VERSION

--- a/dockerfiles/libproj-builder
+++ b/dockerfiles/libproj-builder
@@ -3,7 +3,7 @@
 # Builds libproj from source
 
 ARG RUST_VERSION
-FROM rust:$RUST_VERSION-bullseye
+FROM rust:$RUST_VERSION-slim-bullseye
 
 ARG RUST_VERSION
 ARG PROJ_VERSION


### PR DESCRIPTION
This is an attempt to reduce our æons-long image rebuilds (and `geo` and `proj`'s CI too ofc). It drops the base image size from 1.33 GB to 754 MB uncompressed, and the final libproj-builder image from 2.00 GB to 1.57 GB uncompressed (~21% reduction).

Dependent image size reduction:

geo-ci: from ~1.58 GB --> 1.15 GB
proj-ci: from ~2.02 GB --> 1.59 GB
proj-ci-without-system-proj: from ~2.00 GB --> 1.57 GB

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
